### PR TITLE
add serializable wrapper for StanfordCoreNLP class

### DIFF
--- a/src/main/scala/com/databricks/spark/corenlp/CoreNLP.scala
+++ b/src/main/scala/com/databricks/spark/corenlp/CoreNLP.scala
@@ -69,10 +69,10 @@ class CoreNLP(override val uid: String) extends Transformer {
   override def transform(dataset: DataFrame): DataFrame = {
     val props = new Properties()
     props.setProperty(annotators.name, $(annotators).mkString(","))
+    val wrapper = new StanfordCoreNLPWrapper(props)
     val f = { text: String =>
-      val coreNLP = new StanfordCoreNLP(props)
       val doc = new Annotation(text)
-      coreNLP.annotate(doc)
+      wrapper.get.annotate(doc)
       val serializer = new ProtobufAnnotationSerializer()
       val row = CoreNLP.convertMessage(serializer.toProto(doc), docSchema)
       Row(row.toSeq ++ $(flattenNestedFields).map(flatten(row, docSchema, _)): _*)

--- a/src/main/scala/com/databricks/spark/corenlp/StanfordCoreNLPWrapper.scala
+++ b/src/main/scala/com/databricks/spark/corenlp/StanfordCoreNLPWrapper.scala
@@ -1,0 +1,21 @@
+package com.databricks.spark.corenlp
+
+import java.util.Properties
+
+import edu.stanford.nlp.pipeline.StanfordCoreNLP
+
+/**
+ * A serializable wrapper of [[StanfordCoreNLP]].
+ * @param props properties used to construct [[StanfordCoreNLP]]
+ */
+class StanfordCoreNLPWrapper(private val props: Properties) extends Serializable {
+  @transient private var coreNLP: StanfordCoreNLP = _
+
+  /** Returns the contained [[StanfordCoreNLP]] instance. */
+  def get: StanfordCoreNLP = {
+    if (coreNLP == null) {
+      coreNLP = new StanfordCoreNLP(props)
+    }
+    coreNLP
+  }
+}


### PR DESCRIPTION
to avoid creating multiple `StanfordCoreNLP` instances.