### PR TITLE
Build with Spark 2.3.1, drop Scala 2.10 support, update sbt and sbt-spark-package version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 
 scala:
-  - 2.10.6
   - 2.11.8
 
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "spark-corenlp"
 
 version := "0.3.0-SNAPSHOT"
 
-crossScalaVersions := Seq("2.11.8", "2.10.6")
+scalaVersion := "2.11.12"
 
 scalacOptions ++= Seq(
   "-encoding", "UTF-8",

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "spark-corenlp"
 
 version := "0.3.0-SNAPSHOT"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq(
   "-encoding", "UTF-8",
@@ -29,7 +29,7 @@ initialize := {
 }
 
 lazy val nlpVersion = "3.7.0"
-sparkVersion := "2.1.0"
+sparkVersion := "2.3.1"
 
 // change the value below to change the directory where your zip artifact will be created
 spDistDirectory := target.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 // This file should only contain the version of sbt to use.
-sbt.version=0.13.12
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@
 
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")


### PR DESCRIPTION
Hello,
We (with @nekonyuu ) changed :
* the version of SBT
* the version of the plugin sbt-spark-package
removed :
* the crosscompilation for scala 2.10.6